### PR TITLE
Add WebAssembly learning web app (Fibonacci benchmark + structure viewer)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════
+# build.sh - Rust → WebAssembly ビルドスクリプト
+#
+# このスクリプト自体が学習教材です。各ステップのコメントを読んでください。
+# ═══════════════════════════════════════════════════════════════════
+set -e
+
+echo ""
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║   Rust + WebAssembly 学習アプリ ビルドスクリプト      ║"
+echo "╚══════════════════════════════════════════════════════╝"
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+# STEP 1: wasm-pack のインストール確認
+#
+# wasm-pack は Rust → WebAssembly のビルドを自動化するツールです。
+# 内部でやること:
+#   1. cargo build --target wasm32-unknown-unknown --release
+#   2. wasm-bindgen CLI で JS グルーコードを生成
+#   3. (オプション) wasm-opt でバイナリを最適化
+# ───────────────────────────────────────────────────────────────────
+echo "STEP 1: wasm-pack を確認..."
+if ! command -v wasm-pack &>/dev/null; then
+  echo "  wasm-pack が見つかりません。インストールします..."
+  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+  echo "  ✓ wasm-pack インストール完了"
+else
+  echo "  ✓ wasm-pack: $(wasm-pack --version)"
+fi
+
+# ───────────────────────────────────────────────────────────────────
+# STEP 2: wasm32-unknown-unknown ターゲットの追加
+#
+# Rust のクロスコンパイルには「ターゲットトリプル」が必要です。
+#   wasm32-unknown-unknown の意味:
+#     wasm32       = 32bit WebAssembly アーキテクチャ
+#     unknown      = OS なし（ブラウザの VM 上で動く）
+#     unknown      = ABI なし（libc を使わない）
+#
+# これにより:
+#   - std::fs, std::net など OS 依存の機能は使えない
+#   - JS ホストから提供された機能だけを使う（= imports）
+#   - バイナリサイズが小さくなる
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo "STEP 2: wasm32 コンパイルターゲットを追加..."
+rustup target add wasm32-unknown-unknown 2>/dev/null || true
+echo "  ✓ wasm32-unknown-unknown ターゲット: 準備完了"
+
+# ───────────────────────────────────────────────────────────────────
+# STEP 3: Rust → WebAssembly コンパイル
+#
+# wasm-pack build オプションの説明:
+#   --target web
+#     ES module 形式で出力（import/export を使う）。
+#     バンドラー（Webpack/Vite）不要で直接ブラウザで動く。
+#     --target bundler にすると Node.js/バンドラー向けになる。
+#
+#   --release
+#     最適化ビルド。opt-level="s" が Cargo.toml で設定済み。
+#     デバッグビルドは .wasm が数倍大きくなり遅い。
+#
+#   --out-dir ../www/pkg
+#     生成ファイルの出力先。www/ から直接 import できるよう配置。
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo "STEP 3: Rust を WebAssembly にコンパイル..."
+cd "$(dirname "$0")/wasm"
+wasm-pack build --target web --release --out-dir ../www/pkg
+cd ..
+echo "  ✓ コンパイル完了"
+
+# ───────────────────────────────────────────────────────────────────
+# STEP 4: 生成ファイルの確認（学習ポイント）
+#
+# wasm-pack が生成するファイル:
+#   fib_wasm_bg.wasm  - 実際の WebAssembly バイナリ
+#   fib_wasm.js       - wasm-bindgen の JS グルーコード（必読！）
+#   fib_wasm.d.ts     - TypeScript 型定義（export 一覧がわかる）
+#   package.json      - npm パッケージメタデータ
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo "STEP 4: 生成ファイルの確認"
+echo ""
+echo "  ファイル一覧:"
+ls -lh www/pkg/ | grep -v "^total" | awk '{printf "    %-40s %s\n", $9, $5}'
+echo ""
+
+WASM_SIZE=$(stat -f%z www/pkg/fib_wasm_bg.wasm 2>/dev/null || stat -c%s www/pkg/fib_wasm_bg.wasm 2>/dev/null || echo "?")
+echo "  Wasm バイナリサイズ: ${WASM_SIZE} バイト"
+echo ""
+echo "  ─────────────────────────────────────────────────────"
+echo "  [学習推奨] 以下のファイルを読んでみましょう:"
+echo ""
+echo "  1. www/pkg/fib_wasm.js"
+echo "     → wasm-bindgen が生成した JS グルーコード"
+echo "       型変換（i32 ↔ Number, i64 ↔ BigInt, &str → JS String）の"
+echo "       実装が読める。このファイルを理解すれば Wasm interop が分かる。"
+echo ""
+echo "  2. www/pkg/fib_wasm.d.ts"
+echo "     → TypeScript 型定義。export された関数の型シグネチャ一覧。"
+echo ""
+echo "  3. WAT テキスト形式（要 wabt）:"
+echo "     sudo apt install wabt"
+echo "     wasm2wat www/pkg/fib_wasm_bg.wasm | less"
+echo "     → .wasm バイナリの人間が読める形式。Panel 3 のカードと照合できる。"
+echo "  ─────────────────────────────────────────────────────"
+echo ""
+
+# ───────────────────────────────────────────────────────────────────
+# STEP 5: HTTP サーバーの起動
+#
+# なぜ file:// URL で開けないのか？
+#   ブラウザは .wasm ファイルを application/wasm MIME type として
+#   サーブするサーバーからのみ受け付ける（セキュリティ制約）。
+#   file:// URL からは CORS エラーで fetch() が失敗する。
+#   → 必ず HTTP サーバー経由でアクセスすること。
+# ───────────────────────────────────────────────────────────────────
+echo "STEP 5: HTTP サーバーを起動します"
+echo ""
+echo "  ブラウザで以下を開いてください:"
+echo "  → http://localhost:8080"
+echo ""
+echo "  終了するには Ctrl+C を押してください。"
+echo ""
+python3 -m http.server 8080 --directory www

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "fib_wasm"
+version = "0.1.0"
+edition = "2021"
+
+# LEARNING NOTE: crate-type = ["cdylib"] tells rustc to produce a C-compatible
+# dynamic library. wasm-pack then wraps this .wasm file with JS glue code.
+# Without this, cargo produces a rlib (Rust library) which is not loadable by browsers.
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# wasm-bindgen generates the JS/Wasm boundary code automatically.
+# It reads #[wasm_bindgen] attributes and emits:
+#   - JavaScript wrapper functions (see www/pkg/fib_wasm.js after build)
+#   - TypeScript type definitions (see www/pkg/fib_wasm.d.ts after build)
+#   - The glue that maps JS types to/from Wasm linear memory types
+wasm-bindgen = "0.2"
+
+[profile.release]
+# opt-level = "s" optimizes for size, not speed.
+# Wasm binaries are downloaded by the browser, so size matters.
+# "s" = shrink code size; this also makes the WAT output easier to read.
+opt-level = "s"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,0 +1,118 @@
+// LEARNING NOTE: No `fn main()` here!
+// A Wasm module is a LIBRARY, not an executable.
+// The browser is the runtime. It loads and calls into this module.
+// Compare this to src/main.rs - that is a native binary with a main().
+// This is lib.rs - it exposes functions for others to call.
+
+use wasm_bindgen::prelude::*;
+
+// ═══════════════════════════════════════════════════════════════════
+// CONCEPT 1: EXPORTS
+//
+// #[wasm_bindgen] marks this function as a Wasm EXPORT.
+// In the compiled .wasm binary, the "export" section contains:
+//   (export "fibonacci" (func $fibonacci))
+//
+// This is what allows JavaScript to call: wasmModule.fibonacci(n)
+//
+// Wasm type signature: (i32) -> i64
+// JavaScript sees it as: (Number) -> BigInt
+// (because i64 can exceed Number.MAX_SAFE_INTEGER, wasm-bindgen uses BigInt)
+// ═══════════════════════════════════════════════════════════════════
+#[wasm_bindgen]
+pub fn fibonacci(n: u32) -> u64 {
+    fib_inner(n)
+}
+
+// LEARNING NOTE: This function is NOT marked #[wasm_bindgen].
+// Therefore it does NOT appear in the Wasm export section.
+// It exists in the "code" section of the binary, but JavaScript
+// cannot call it - it's an internal implementation detail.
+// This demonstrates that Wasm respects information hiding.
+fn fib_inner(n: u32) -> u64 {
+    // Intentionally naive recursive implementation.
+    // At n=42 this does ~866 million recursive calls.
+    // JS handles this slowly (dynamic typing overhead),
+    // but Wasm executes integer arithmetic on a typed stack machine -
+    // no boxing, no GC, no type checks. That's where the speedup comes from.
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fib_inner(n - 1) + fib_inner(n - 2),
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// CONCEPT 2: LINEAR MEMORY (zero-copy sharing)
+//
+// Wasm linear memory is a flat, byte-addressable array shared between
+// the Wasm module and JavaScript. Both can read and write it.
+//
+// When JS passes a Uint32Array to this function, wasm-bindgen arranges
+// for Rust to receive a slice pointing into the SAME memory region.
+// No data is copied. This is the zero-copy model.
+//
+// After calling this function, JS can immediately read the results
+// from the original Uint32Array - Rust wrote directly into it.
+// ═══════════════════════════════════════════════════════════════════
+#[wasm_bindgen]
+pub fn fill_fibonacci_sequence(buffer: &mut [u32]) {
+    if buffer.is_empty() {
+        return;
+    }
+    if buffer.len() == 1 {
+        buffer[0] = 0;
+        return;
+    }
+    buffer[0] = 0;
+    buffer[1] = 1;
+    for i in 2..buffer.len() {
+        // saturating_add: clamp at u32::MAX instead of wrapping/panicking
+        buffer[i] = buffer[i - 1].saturating_add(buffer[i - 2]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// CONCEPT 3: IMPORTS (Wasm calling INTO JavaScript)
+//
+// Wasm is sandboxed - it cannot do I/O on its own.
+// It must IMPORT capabilities from the host (JavaScript).
+//
+// extern "C" { fn log(s: &str); } tells wasm-bindgen:
+//   "console.log exists in the JS host; let me call it."
+//
+// In the compiled .wasm binary, the "import" section contains:
+//   (import "wbg" "__wbg_log_..." (func ...))
+//
+// JS is the "host". Wasm is the "guest". The guest asks the host
+// for capabilities it cannot provide itself.
+// ═══════════════════════════════════════════════════════════════════
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// CONCEPT 4: RETURNING COMPLEX TYPES (strings cross the boundary)
+//
+// Wasm functions natively return only numeric primitives: i32, i64, f32, f64.
+// To return a String, wasm-bindgen:
+//   1. Allocates bytes for the string in Wasm linear memory
+//   2. Returns a (pointer: i32, length: i32) pair
+//   3. The JS glue reads those bytes and reconstructs a JS String
+//
+// This is the key insight: "complex types" are just linear memory
+// + a convention about how to interpret the bytes.
+// ═══════════════════════════════════════════════════════════════════
+#[wasm_bindgen]
+pub fn get_module_info() -> String {
+    // Calling log() here demonstrates the import concept:
+    // This Rust code, compiled to Wasm, calls back into JavaScript.
+    log("[Wasm] get_module_info() called - this log came from Rust via Wasm import!");
+    String::from(
+        "fib_wasm v0.1.0 | \
+         Exports: fibonacci, fill_fibonacci_sequence, get_module_info | \
+         Hint: read www/pkg/fib_wasm.js to see how types cross the boundary"
+    )
+}

--- a/www/app.js
+++ b/www/app.js
@@ -1,0 +1,180 @@
+// ═══════════════════════════════════════════════════════════════════
+// app.js - WebAssembly 学習アプリのメイン JS
+//
+// LEARNING NOTE: type="module" が必要な理由
+//   wasm-pack が生成する fib_wasm.js は ES module (import/export を使う)。
+//   ブラウザでは <script type="module"> からのみ import できる。
+//   また、ES module は自動的に Strict Mode で動作する。
+// ═══════════════════════════════════════════════════════════════════
+
+// LEARNING NOTE: Wasm モジュールの読み込みは非同期。
+//   init() が内部でやること:
+//     1. fetch("fib_wasm_bg.wasm") - バイナリを HTTP で取得
+//     2. WebAssembly.compile(bytes) - ブラウザの Wasm エンジンでコンパイル
+//     3. WebAssembly.instantiate(module, imports) - 実行可能インスタンスを作成
+//   これが完了して初めて fibonacci() などの関数が呼べるようになる。
+import init, {
+  fibonacci,
+  fill_fibonacci_sequence,
+  get_module_info,
+} from './pkg/fib_wasm.js';
+
+// ── JavaScript 版フィボナッチ（公平な比較のため同じアルゴリズム）────
+// JS では数値型は実行時に決まる。エンジンは毎回「これは数値か？」を確認する。
+function fibonacci_js(n) {
+  if (n <= 1) return n;
+  return fibonacci_js(n - 1) + fibonacci_js(n - 2);
+}
+
+// ── ベンチマーク実行ヘルパー ────────────────────────────────────────
+function runJsBenchmark(n) {
+  const t0 = performance.now();
+  const result = fibonacci_js(n);
+  const elapsed = performance.now() - t0;
+  return { result, elapsed };
+}
+
+function runWasmBenchmark(n) {
+  const t0 = performance.now();
+  // LEARNING NOTE: fibonacci() は Rust/Wasm から export された関数。
+  //   wasm-bindgen が JS Number を Wasm の i32 に変換して渡す。
+  //   Wasm は i64 で結果を返すが、i64 は Number の安全整数範囲を超えることがある。
+  //   そのため wasm-bindgen は BigInt で返す。Number() で変換して表示する。
+  const result = fibonacci(n);
+  const elapsed = performance.now() - t0;
+  return { result: Number(result), elapsed };
+}
+
+// ── Panel 1: ベンチマーク UI ────────────────────────────────────────
+function setupBenchmarkPanel() {
+  const fibNInput = document.getElementById('fib-n');
+  const fibNDisplay = document.getElementById('fib-n-display');
+
+  fibNInput.addEventListener('input', () => {
+    fibNDisplay.textContent = fibNInput.value;
+  });
+
+  document.getElementById('btn-run-js').addEventListener('click', () => {
+    const n = parseInt(fibNInput.value);
+    const { result, elapsed } = runJsBenchmark(n);
+    document.getElementById('js-result').textContent = result;
+    document.getElementById('js-time').textContent = elapsed.toFixed(1) + ' ms';
+  });
+
+  document.getElementById('btn-run-wasm').addEventListener('click', () => {
+    const n = parseInt(fibNInput.value);
+    const { result, elapsed } = runWasmBenchmark(n);
+    document.getElementById('wasm-result').textContent = result;
+    document.getElementById('wasm-time').textContent = elapsed.toFixed(1) + ' ms';
+  });
+
+  document.getElementById('btn-run-both').addEventListener('click', () => {
+    const n = parseInt(fibNInput.value);
+
+    // JS を先に実行（遅いため）
+    const js = runJsBenchmark(n);
+    const wasm = runWasmBenchmark(n);
+
+    document.getElementById('js-result').textContent = js.result;
+    document.getElementById('js-time').textContent = js.elapsed.toFixed(1) + ' ms';
+    document.getElementById('wasm-result').textContent = wasm.result;
+    document.getElementById('wasm-time').textContent = wasm.elapsed.toFixed(1) + ' ms';
+
+    const speedupEl = document.getElementById('speedup');
+    if (wasm.elapsed > 0) {
+      const speedup = js.elapsed / wasm.elapsed;
+      speedupEl.textContent = speedup.toFixed(1);
+    } else {
+      speedupEl.textContent = '∞';
+    }
+  });
+}
+
+// ── Panel 2: Linear Memory ビューア ─────────────────────────────────
+function setupMemoryPanel(wasmModule) {
+  document.getElementById('btn-fill').addEventListener('click', () => {
+    const len = Math.min(50, Math.max(1, parseInt(document.getElementById('seq-len').value) || 16));
+
+    // LEARNING NOTE: new Uint32Array(len) で作ったバッファを Wasm に渡す。
+    //   wasm-bindgen は (pointer, length) ペアを Wasm 側に渡す。
+    //   Rust では &mut [u32] として受け取り、同じメモリ領域に直接書き込む。
+    //   コピーは一切発生しない。これがゼロコピーの本質。
+    const buffer = new Uint32Array(len);
+    fill_fibonacci_sequence(buffer);
+
+    // バッファをそのまま読む（Rust が書き込んだ内容がそのまま見える）
+    const grid = document.getElementById('memory-display');
+    grid.innerHTML = '';
+    buffer.forEach((val, idx) => {
+      const cell = document.createElement('div');
+      cell.className = 'memory-cell';
+      cell.innerHTML =
+        `<span class="cell-idx">fib(${idx})</span>` +
+        `<span class="cell-val">${val.toLocaleString()}</span>`;
+      grid.appendChild(cell);
+    });
+
+    // LEARNING NOTE: WebAssembly.Memory は実体が SharedArrayBuffer に近い ArrayBuffer。
+    //   .buffer.byteLength で Linear Memory の現在のバイト数がわかる。
+    //   1 ページ = 65,536 バイト。Wasm モジュールは必要に応じてページを追加できる。
+    const memory = wasmModule.memory;
+    const byteLen = memory.buffer.byteLength;
+    const pages = byteLen / 65536;
+    document.getElementById('memory-info').textContent =
+      `Wasm Linear Memory: ${byteLen.toLocaleString()} バイト ` +
+      `（${pages} ページ × 64 KiB）| ` +
+      `バッファは Wasm メモリのアドレス空間内に配置され、JS と Rust が共有しています`;
+  });
+}
+
+// ── Panel 3: Module Anatomy - セクションカードのクリック展開 ─────────
+function setupAnatomyPanel() {
+  let expandedCard = null;
+
+  document.querySelectorAll('.section-card').forEach(card => {
+    card.addEventListener('click', () => {
+      if (expandedCard && expandedCard !== card) {
+        expandedCard.classList.remove('expanded');
+      }
+      card.classList.toggle('expanded');
+      expandedCard = card.classList.contains('expanded') ? card : null;
+    });
+  });
+}
+
+// ── メイン: Wasm 初期化と全パネルのセットアップ ──────────────────────
+async function main() {
+  const statusEl = document.getElementById('module-status');
+
+  try {
+    // LEARNING NOTE: init() は wasm-pack が生成した関数。
+    //   内部では fetch → compile → instantiate を行い、
+    //   WebAssembly.Instance オブジェクト（≈ wasmModule）を返す。
+    //   このオブジェクトには .memory（WebAssembly.Memory）が含まれる。
+    const wasmModule = await init();
+
+    // Wasm から情報取得（これ自体が import の実証: Rust が console.log を呼ぶ）
+    const info = get_module_info();
+    statusEl.textContent = '✓ Wasm 準備完了 | ' + info;
+    statusEl.className = 'status-bar ready';
+
+    // 各パネルのセットアップ
+    setupBenchmarkPanel();
+    setupMemoryPanel(wasmModule);
+    setupAnatomyPanel();
+
+    // ボタンを有効化
+    document.querySelectorAll('button').forEach(btn => {
+      btn.disabled = false;
+    });
+
+  } catch (err) {
+    statusEl.textContent = '✗ Wasm の読み込みに失敗: ' + err.message;
+    statusEl.className = 'status-bar error';
+    console.error('Wasm 初期化エラー:', err);
+    console.error('ヒント: python3 -m http.server 8080 でサーブしていますか？');
+    console.error('file:// URL では .wasm ファイルは読み込めません（MIME type 制約）');
+  }
+}
+
+main();

--- a/www/index.html
+++ b/www/index.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rust + WebAssembly 学習アプリ</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <header>
+    <h1>Rust + WebAssembly 学習アプリ</h1>
+    <p class="subtitle">
+      WebAssembly は、ブラウザ上で動くバイナリフォーマットです。
+      Rust コードをコンパイルすると <code>.wasm</code> ファイルになり、
+      JavaScript から高速な関数として呼び出せます。
+      以下の 3 パネルで、そのしくみを実際に体験してください。
+    </p>
+    <div id="module-status" class="status-bar loading">Wasm モジュールを読み込み中...</div>
+  </header>
+
+  <main class="grid">
+
+    <!-- ═══════════════════════════════════════════════════════ -->
+    <!-- PANEL 1: BENCHMARK                                      -->
+    <!-- 学習コンセプト: Exports / Wasm の型システム / 性能       -->
+    <!-- ═══════════════════════════════════════════════════════ -->
+    <section class="panel" id="panel-benchmark">
+      <div class="panel-header">
+        <h2>Panel 1: ベンチマーク</h2>
+        <span class="badge">Exports &amp; 型システム</span>
+      </div>
+
+      <p class="concept-note">
+        JavaScript と WebAssembly で<strong>まったく同じアルゴリズム</strong>
+        （再帰フィボナッチ）を実行し、速度を比較します。
+        「Run Both」を N=42 以上で試してください。
+      </p>
+
+      <div class="controls">
+        <label>
+          N =
+          <input type="range" id="fib-n" min="30" max="45" value="38">
+          <span id="fib-n-display" class="value-display">38</span>
+        </label>
+      </div>
+
+      <div class="button-row">
+        <button id="btn-run-js" class="btn-js">JavaScript で実行</button>
+        <button id="btn-run-wasm" class="btn-wasm">WebAssembly で実行</button>
+        <button id="btn-run-both" class="btn-both">両方実行して比較</button>
+      </div>
+
+      <div class="results-grid">
+        <div class="result-card js-card">
+          <div class="result-label">JavaScript</div>
+          <div class="result-value" id="js-result">--</div>
+          <div class="result-time" id="js-time">-- ms</div>
+        </div>
+        <div class="speedup-card">
+          <div class="speedup-label">Wasm 速度比</div>
+          <div class="speedup-value" id="speedup">--</div>
+          <div class="speedup-unit">倍</div>
+        </div>
+        <div class="result-card wasm-card">
+          <div class="result-label">WebAssembly</div>
+          <div class="result-value" id="wasm-result">--</div>
+          <div class="result-time" id="wasm-time">-- ms</div>
+        </div>
+      </div>
+
+      <details class="explainer">
+        <summary>なぜ Wasm が速いのか？</summary>
+        <div class="explainer-body">
+          <p>
+            JavaScript は動的型付き言語です。変数の型は実行時に決まり、
+            エンジンは「この変数は数値か？文字列か？」を毎回確認します。
+            WebAssembly は静的型付きのスタックマシンです。
+            すべての型はコンパイル時に確定しており、型チェックは不要です。
+          </p>
+          <p>Wasm の関数はコンパイル後の <code>.wasm</code> 内でこう見えます：</p>
+          <pre class="wat"><span class="wat-comment">;; export セクション: JS から呼べる関数の一覧</span>
+<span class="wat-paren">(</span><span class="wat-keyword">export</span> <span class="wat-string">"fibonacci"</span> <span class="wat-paren">(</span><span class="wat-keyword">func</span> <span class="wat-name">$fibonacci</span><span class="wat-paren">))</span>
+
+<span class="wat-comment">;; type セクション: すべての型はコンパイル時に確定</span>
+<span class="wat-paren">(</span><span class="wat-keyword">type</span> <span class="wat-paren">(</span><span class="wat-keyword">func</span> <span class="wat-paren">(</span><span class="wat-keyword">param</span> <span class="wat-type">i32</span><span class="wat-paren">)</span> <span class="wat-paren">(</span><span class="wat-keyword">result</span> <span class="wat-type">i64</span><span class="wat-paren">)))</span>
+
+<span class="wat-comment">;; Wasm の型は 4 種類だけ: i32, i64, f32, f64</span>
+<span class="wat-comment">;; 動的型付けなし → 型チェックのオーバーヘッドなし</span></pre>
+        </div>
+      </details>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════ -->
+    <!-- PANEL 2: LINEAR MEMORY                                  -->
+    <!-- 学習コンセプト: JS と Wasm がメモリを直接共有する       -->
+    <!-- ═══════════════════════════════════════════════════════ -->
+    <section class="panel" id="panel-memory">
+      <div class="panel-header">
+        <h2>Panel 2: Linear Memory</h2>
+        <span class="badge">ゼロコピー共有</span>
+      </div>
+
+      <p class="concept-note">
+        WebAssembly の<strong>Linear Memory</strong>は、Wasm と JS が共有する
+        単一のフラットなバイト配列です。Rust がそこにデータを書き込み、
+        JS が同じメモリを直接読み取ります。コピーは発生しません。
+      </p>
+
+      <div class="controls">
+        <label>
+          数列の長さ:
+          <input type="number" id="seq-len" min="5" max="50" value="16">
+        </label>
+        <button id="btn-fill" class="btn-wasm">Wasm で書き込む（ゼロコピー）</button>
+      </div>
+
+      <div id="memory-display" class="memory-grid"></div>
+
+      <div id="memory-info" class="info-bar">
+        「Wasm で書き込む」を押すと Rust がバッファに直接書き込みます。
+      </div>
+
+      <details class="explainer">
+        <summary>ゼロコピーとは？</summary>
+        <div class="explainer-body">
+          <p>
+            JS で <code>new Uint32Array(len)</code> を作ると、そのバッファは
+            Wasm の Linear Memory の一部になります。
+            <code>fill_fibonacci_sequence(buffer)</code> を呼ぶと、
+            wasm-bindgen は「バッファのポインタと長さ」を Wasm に渡します。
+            Rust 側では <code>&mut [u32]</code> としてその領域を直接操作します。
+            JS はその後、同じ <code>Uint32Array</code> を読むだけで結果を得ます。
+          </p>
+          <pre class="wat"><span class="wat-comment">;; memory セクション: Linear Memory の宣言</span>
+<span class="wat-paren">(</span><span class="wat-keyword">memory</span> <span class="wat-paren">(</span><span class="wat-keyword">export</span> <span class="wat-string">"memory"</span><span class="wat-paren">)</span> <span class="wat-number">1</span><span class="wat-paren">)</span>
+<span class="wat-comment">;; 1 ページ = 64 KiB (65,536 バイト)</span>
+<span class="wat-comment">;; JS から: wasmModule.memory.buffer で ArrayBuffer として参照可能</span>
+<span class="wat-comment">;; Rust から: Vec, slice などが使うヒープ領域</span></pre>
+          <p>
+            JS コード側：
+          </p>
+          <pre class="code-js">const buffer = new Uint32Array(16);
+fill_fibonacci_sequence(buffer);  <span class="code-comment">// Rust が直接書き込む</span>
+console.log(buffer[7]);           <span class="code-comment">// コピーなしで読める</span>
+
+<span class="code-comment">// Linear Memory の実体を確認</span>
+const memory = wasmModule.memory;
+console.log(memory.buffer.byteLength);  <span class="code-comment">// 例: 65536 バイト</span></pre>
+        </div>
+      </details>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════ -->
+    <!-- PANEL 3: MODULE ANATOMY                                 -->
+    <!-- 学習コンセプト: .wasm バイナリの内部構造                -->
+    <!-- ═══════════════════════════════════════════════════════ -->
+    <section class="panel panel-full" id="panel-anatomy">
+      <div class="panel-header">
+        <h2>Panel 3: モジュール構造（WAT）</h2>
+        <span class="badge">バイナリ構造</span>
+      </div>
+
+      <p class="concept-note">
+        <code>.wasm</code> バイナリは決まったセクション構造を持ちます。
+        各カードをクリックして、セクションの役割と実際の WAT（テキスト形式）を確認してください。
+        WAT は <code>wasm2wat fib_wasm_bg.wasm</code> コマンドで生成できます。
+      </p>
+
+      <div class="module-sections">
+
+        <div class="section-card" data-section="type">
+          <div class="section-id">§1</div>
+          <div class="section-name">Type セクション</div>
+          <div class="section-desc">関数シグネチャ（型）の定義</div>
+          <div class="section-detail">
+            <pre class="wat"><span class="wat-comment">;; すべての関数型をここで定義する</span>
+<span class="wat-comment">;; Wasm は静的型付き → 型はコンパイル時に確定</span>
+<span class="wat-paren">(</span><span class="wat-keyword">type</span> <span class="wat-name">$t0</span> <span class="wat-paren">(</span><span class="wat-keyword">func</span> <span class="wat-paren">(</span><span class="wat-keyword">param</span> <span class="wat-type">i32</span><span class="wat-paren">)</span> <span class="wat-paren">(</span><span class="wat-keyword">result</span> <span class="wat-type">i64</span><span class="wat-paren">)))</span>
+<span class="wat-comment">;; fibonacci: i32 を受け取り i64 を返す</span>
+
+<span class="wat-paren">(</span><span class="wat-keyword">type</span> <span class="wat-name">$t1</span> <span class="wat-paren">(</span><span class="wat-keyword">func</span> <span class="wat-paren">(</span><span class="wat-keyword">param</span> <span class="wat-type">i32</span> <span class="wat-type">i32</span><span class="wat-paren">)))</span>
+<span class="wat-comment">;; fill_fibonacci_sequence: (pointer: i32, length: i32)</span>
+<span class="wat-comment">;; スライス = ポインタ + 長さ の 2 つの i32</span>
+
+<span class="wat-comment">;; Wasm の基本型は 4 つだけ:</span>
+<span class="wat-comment">;;   i32 (32bit整数), i64 (64bit整数)</span>
+<span class="wat-comment">;;   f32 (32bit浮動小数), f64 (64bit浮動小数)</span></pre>
+          </div>
+        </div>
+
+        <div class="section-card" data-section="import">
+          <div class="section-id">§2</div>
+          <div class="section-name">Import セクション</div>
+          <div class="section-desc">JS ホストから借りる機能</div>
+          <div class="section-detail">
+            <pre class="wat"><span class="wat-comment">;; Wasm はサンドボックス: I/O は自力でできない</span>
+<span class="wat-comment">;; JS ホストから必要な機能を "import" する</span>
+
+<span class="wat-comment">;; console.log を JS から借りる</span>
+<span class="wat-paren">(</span><span class="wat-keyword">import</span> <span class="wat-string">"wbg"</span> <span class="wat-string">"__wbg_log_..."</span>
+  <span class="wat-paren">(</span><span class="wat-keyword">func</span> <span class="wat-name">$log</span> <span class="wat-paren">(</span><span class="wat-keyword">param</span> <span class="wat-type">i32</span> <span class="wat-type">i32</span><span class="wat-paren">)))</span>
+
+<span class="wat-comment">;; メモリアロケーター (Rust の Vec 等のため)</span>
+<span class="wat-paren">(</span><span class="wat-keyword">import</span> <span class="wat-string">"wbg"</span> <span class="wat-string">"__wbindgen_malloc"</span>
+  <span class="wat-paren">(</span><span class="wat-keyword">func</span> <span class="wat-name">$malloc</span> <span class="wat-paren">(</span><span class="wat-keyword">param</span> <span class="wat-type">i32</span> <span class="wat-type">i32</span><span class="wat-paren">)</span> <span class="wat-paren">(</span><span class="wat-keyword">result</span> <span class="wat-type">i32</span><span class="wat-paren">)))</span>
+
+<span class="wat-comment">;; Rust の extern "C" { fn log(s: &str); } がこれに対応</span>
+<span class="wat-comment">;; JS = ホスト, Wasm = ゲスト。ゲストがホストに頼む。</span></pre>
+          </div>
+        </div>
+
+        <div class="section-card" data-section="memory">
+          <div class="section-id">§5</div>
+          <div class="section-name">Memory セクション</div>
+          <div class="section-desc">Linear Memory の宣言</div>
+          <div class="section-detail">
+            <pre class="wat"><span class="wat-comment">;; 1 ページ = 64 KiB (65,536 バイト)</span>
+<span class="wat-paren">(</span><span class="wat-keyword">memory</span> <span class="wat-paren">(</span><span class="wat-keyword">export</span> <span class="wat-string">"memory"</span><span class="wat-paren">)</span> <span class="wat-number">1</span><span class="wat-paren">)</span>
+
+<span class="wat-comment">;; Linear Memory の特徴:</span>
+<span class="wat-comment">;;   - アドレス 0 から始まる連続バイト配列</span>
+<span class="wat-comment">;;   - Rust の Vec&lt;T&gt; や String はここに配置される</span>
+<span class="wat-comment">;;   - JS から WebAssembly.Memory.buffer で参照可能</span>
+<span class="wat-comment">;;   - memory.grow(n) で 64KiB × n ページ分拡張できる</span>
+<span class="wat-comment">;;   - OS のスタック/ヒープとは別物</span>
+
+<span class="wat-comment">;; Panel 2 で確認したゼロコピーはこのメモリを使っている</span></pre>
+          </div>
+        </div>
+
+        <div class="section-card" data-section="export">
+          <div class="section-id">§7</div>
+          <div class="section-name">Export セクション</div>
+          <div class="section-desc">JS に公開する関数・メモリ</div>
+          <div class="section-detail">
+            <pre class="wat"><span class="wat-comment">;; JS が呼べるのは export された関数だけ</span>
+<span class="wat-comment">;; #[wasm_bindgen] を付けた pub fn が export される</span>
+
+<span class="wat-paren">(</span><span class="wat-keyword">export</span> <span class="wat-string">"fibonacci"</span> <span class="wat-paren">(</span><span class="wat-keyword">func</span> <span class="wat-name">$fibonacci</span><span class="wat-paren">))</span>
+<span class="wat-paren">(</span><span class="wat-keyword">export</span> <span class="wat-string">"fill_fibonacci_sequence"</span>
+  <span class="wat-paren">(</span><span class="wat-keyword">func</span> <span class="wat-name">$fill_fibonacci_sequence</span><span class="wat-paren">))</span>
+<span class="wat-paren">(</span><span class="wat-keyword">export</span> <span class="wat-string">"get_module_info"</span> <span class="wat-paren">(</span><span class="wat-keyword">func</span> <span class="wat-name">$get_module_info</span><span class="wat-paren">))</span>
+<span class="wat-paren">(</span><span class="wat-keyword">export</span> <span class="wat-string">"memory"</span> <span class="wat-paren">(</span><span class="wat-keyword">memory</span> <span class="wat-number">0</span><span class="wat-paren">))</span>
+
+<span class="wat-comment">;; fib_inner は export なし → JS からは見えない</span>
+<span class="wat-comment">;; Wasm でも情報隠蔽 (pub/private) が機能する</span></pre>
+          </div>
+        </div>
+
+        <div class="section-card" data-section="code">
+          <div class="section-id">§10</div>
+          <div class="section-name">Code セクション</div>
+          <div class="section-desc">関数の実際のバイトコード</div>
+          <div class="section-detail">
+            <pre class="wat"><span class="wat-comment">;; fibonacci 関数の WAT 表現（簡略化）</span>
+<span class="wat-comment">;; Wasm はスタックマシン: 値をスタックに積み、操作して返す</span>
+<span class="wat-paren">(</span><span class="wat-keyword">func</span> <span class="wat-name">$fibonacci</span> <span class="wat-paren">(</span><span class="wat-keyword">param</span> <span class="wat-name">$n</span> <span class="wat-type">i32</span><span class="wat-paren">)</span> <span class="wat-paren">(</span><span class="wat-keyword">result</span> <span class="wat-type">i64</span><span class="wat-paren">)</span>
+  <span class="wat-paren">(</span><span class="wat-keyword">call</span> <span class="wat-name">$fib_inner</span>  <span class="wat-comment">;; fib_inner を呼ぶ</span>
+    <span class="wat-paren">(</span><span class="wat-keyword">local.get</span> <span class="wat-name">$n</span><span class="wat-paren">)))</span>  <span class="wat-comment">;; 引数をスタックに積む</span>
+
+<span class="wat-paren">(</span><span class="wat-keyword">func</span> <span class="wat-name">$fib_inner</span> <span class="wat-paren">(</span><span class="wat-keyword">param</span> <span class="wat-name">$n</span> <span class="wat-type">i32</span><span class="wat-paren">)</span> <span class="wat-paren">(</span><span class="wat-keyword">result</span> <span class="wat-type">i64</span><span class="wat-paren">)</span>
+  <span class="wat-comment">;; n &lt;= 1 なら n を i64 に変換して返す</span>
+  <span class="wat-paren">(</span><span class="wat-keyword">if</span> <span class="wat-paren">(</span><span class="wat-keyword">result</span> <span class="wat-type">i64</span><span class="wat-paren">)</span>
+      <span class="wat-paren">(</span><span class="wat-keyword">i32.le_u</span> <span class="wat-paren">(</span><span class="wat-keyword">local.get</span> <span class="wat-name">$n</span><span class="wat-paren">)</span> <span class="wat-paren">(</span><span class="wat-keyword">i32.const</span> <span class="wat-number">1</span><span class="wat-paren">))</span>
+    <span class="wat-paren">(</span><span class="wat-keyword">then</span> <span class="wat-paren">(</span><span class="wat-keyword">i64.extend_i32_u</span> <span class="wat-paren">(</span><span class="wat-keyword">local.get</span> <span class="wat-name">$n</span><span class="wat-paren">)))</span>
+    <span class="wat-paren">(</span><span class="wat-keyword">else</span>
+      <span class="wat-paren">(</span><span class="wat-keyword">i64.add</span>
+        <span class="wat-paren">(</span><span class="wat-keyword">call</span> <span class="wat-name">$fib_inner</span> <span class="wat-paren">(</span><span class="wat-keyword">i32.sub</span> <span class="wat-paren">(</span><span class="wat-keyword">local.get</span> <span class="wat-name">$n</span><span class="wat-paren">)</span> <span class="wat-paren">(</span><span class="wat-keyword">i32.const</span> <span class="wat-number">1</span><span class="wat-paren">)))</span>
+        <span class="wat-paren">(</span><span class="wat-keyword">call</span> <span class="wat-name">$fib_inner</span> <span class="wat-paren">(</span><span class="wat-keyword">i32.sub</span> <span class="wat-paren">(</span><span class="wat-keyword">local.get</span> <span class="wat-name">$n</span><span class="wat-paren">)</span> <span class="wat-paren">(</span><span class="wat-keyword">i32.const</span> <span class="wat-number">2</span><span class="wat-paren">))))))</span><span class="wat-paren">)</span></pre>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="anatomy-footer">
+        <p>
+          <strong>実際の WAT を見るには：</strong>
+          <code>sudo apt install wabt &amp;&amp; wasm2wat www/pkg/fib_wasm_bg.wasm</code>
+          を実行してください。また <code>www/pkg/fib_wasm.js</code> を読むと
+          wasm-bindgen が生成した型変換グルーコードを確認できます。
+        </p>
+      </div>
+    </section>
+
+  </main>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/www/style.css
+++ b/www/style.css
@@ -1,0 +1,474 @@
+/* ═══════════════════════════════════════════════════════════
+   Rust + WebAssembly 学習アプリ - スタイルシート
+   ═══════════════════════════════════════════════════════════ */
+
+:root {
+  --wasm-purple: #7c3aed;
+  --wasm-purple-light: #ede9fe;
+  --wasm-purple-dark: #5b21b6;
+  --rust-orange: #c05000;
+  --rust-orange-light: #fff7ed;
+  --js-yellow: #ca8a04;
+  --js-yellow-light: #fefce8;
+  --panel-bg: #ffffff;
+  --panel-border: #e2e8f0;
+  --bg: #f8fafc;
+  --text: #1e293b;
+  --text-muted: #64748b;
+  --code-bg: #1e1e2e;
+  --code-fg: #cdd6f4;
+  --success: #16a34a;
+  --radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+/* ── HEADER ─────────────────────────────────────────────── */
+header {
+  background: linear-gradient(135deg, #4c1d95, #7c3aed);
+  color: white;
+  padding: 1.5rem 2rem;
+}
+
+header h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+
+header .subtitle {
+  font-size: 0.9rem;
+  opacity: 0.85;
+  max-width: 800px;
+}
+
+header code {
+  background: rgba(255,255,255,0.15);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: 'Fira Code', 'Consolas', monospace;
+}
+
+.status-bar {
+  margin-top: 0.75rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+  font-family: 'Fira Code', 'Consolas', monospace;
+  display: inline-block;
+}
+
+.status-bar.loading {
+  background: rgba(255,255,255,0.15);
+  color: #e2e8f0;
+}
+
+.status-bar.ready {
+  background: rgba(22, 163, 74, 0.25);
+  color: #bbf7d0;
+  border: 1px solid rgba(22, 163, 74, 0.4);
+}
+
+.status-bar.error {
+  background: rgba(220, 38, 38, 0.25);
+  color: #fecaca;
+}
+
+/* ── LAYOUT ─────────────────────────────────────────────── */
+main.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto;
+  gap: 1.25rem;
+  padding: 1.25rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.panel-full {
+  grid-column: 1 / -1;
+}
+
+/* ── PANELS ─────────────────────────────────────────────── */
+.panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-top: 3px solid var(--wasm-purple);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.panel-header h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--wasm-purple-dark);
+}
+
+.badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  background: var(--wasm-purple);
+  color: white;
+  padding: 2px 8px;
+  border-radius: 99px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+/* ── CONCEPT NOTES ───────────────────────────────────────── */
+.concept-note {
+  background: var(--wasm-purple-light);
+  border-left: 3px solid var(--wasm-purple);
+  padding: 0.6rem 0.9rem;
+  border-radius: 0 var(--radius) var(--radius) 0;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+  color: #4c1d95;
+}
+
+/* ── CONTROLS ────────────────────────────────────────────── */
+.controls {
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.controls label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-muted);
+}
+
+.controls input[type="range"] {
+  flex: 1;
+  accent-color: var(--wasm-purple);
+}
+
+.controls input[type="number"] {
+  width: 80px;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.value-display {
+  font-family: 'Fira Code', monospace;
+  font-weight: 700;
+  color: var(--wasm-purple);
+  min-width: 2rem;
+  text-align: center;
+}
+
+/* ── BUTTONS ─────────────────────────────────────────────── */
+.button-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+button {
+  padding: 0.45rem 1rem;
+  border: none;
+  border-radius: 5px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s, transform 0.1s;
+}
+
+button:hover { opacity: 0.85; }
+button:active { transform: scale(0.97); }
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-js {
+  background: var(--js-yellow-light);
+  color: #854d0e;
+  border: 1px solid #fde047;
+}
+
+.btn-wasm {
+  background: var(--wasm-purple);
+  color: white;
+}
+
+.btn-both {
+  background: var(--text);
+  color: white;
+}
+
+/* ── BENCHMARK RESULTS ───────────────────────────────────── */
+.results-grid {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.result-card {
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  text-align: center;
+}
+
+.js-card { border-top: 3px solid var(--js-yellow); }
+.wasm-card { border-top: 3px solid var(--wasm-purple); }
+
+.result-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 0.2rem;
+}
+
+.result-value {
+  font-family: 'Fira Code', monospace;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text);
+  word-break: break-all;
+}
+
+.result-time {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 0.2rem;
+}
+
+.speedup-card {
+  text-align: center;
+  padding: 0.5rem;
+}
+
+.speedup-label {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.speedup-value {
+  font-size: 2.2rem;
+  font-weight: 800;
+  color: var(--wasm-purple);
+  line-height: 1;
+}
+
+.speedup-unit {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* ── MEMORY DISPLAY ──────────────────────────────────────── */
+.memory-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.75rem 0;
+  min-height: 3rem;
+}
+
+.memory-cell {
+  border: 1px solid var(--wasm-purple);
+  border-radius: 5px;
+  padding: 0.35rem 0.6rem;
+  text-align: center;
+  min-width: 72px;
+  background: var(--wasm-purple-light);
+}
+
+.cell-idx {
+  display: block;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  font-family: 'Fira Code', monospace;
+}
+
+.cell-val {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 700;
+  font-family: 'Fira Code', monospace;
+  color: var(--wasm-purple-dark);
+}
+
+.info-bar {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: #f1f5f9;
+  padding: 0.5rem 0.75rem;
+  border-radius: 5px;
+  font-family: 'Fira Code', monospace;
+  word-break: break-all;
+}
+
+/* ── MODULE ANATOMY ──────────────────────────────────────── */
+.module-sections {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+  margin: 0.75rem 0;
+}
+
+.section-card {
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  padding: 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  user-select: none;
+}
+
+.section-card:hover {
+  border-color: var(--wasm-purple);
+  box-shadow: 0 0 0 2px var(--wasm-purple-light);
+}
+
+.section-card.expanded {
+  border-color: var(--wasm-purple);
+  background: var(--wasm-purple-light);
+  grid-column: 1 / -1;
+}
+
+.section-id {
+  font-size: 0.7rem;
+  font-family: 'Fira Code', monospace;
+  color: var(--text-muted);
+  margin-bottom: 0.2rem;
+}
+
+.section-name {
+  font-weight: 700;
+  color: var(--wasm-purple-dark);
+  font-size: 0.9rem;
+  margin-bottom: 0.2rem;
+}
+
+.section-desc {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.section-detail {
+  display: none;
+  margin-top: 0.75rem;
+}
+
+.section-card.expanded .section-detail {
+  display: block;
+}
+
+.anatomy-footer {
+  background: #f1f5f9;
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.anatomy-footer code {
+  background: var(--code-bg);
+  color: #89ddff;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.8rem;
+}
+
+/* ── EXPLAINER (details/summary) ─────────────────────────── */
+.explainer {
+  margin-top: 0.75rem;
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.explainer summary {
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--rust-orange);
+  background: var(--rust-orange-light);
+  list-style: none;
+}
+
+.explainer summary::-webkit-details-marker { display: none; }
+.explainer summary::before { content: '▶ '; }
+.explainer[open] summary::before { content: '▼ '; }
+
+.explainer-body {
+  padding: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.explainer-body p {
+  margin-bottom: 0.6rem;
+  color: var(--text-muted);
+}
+
+/* ── CODE BLOCKS ─────────────────────────────────────────── */
+pre.wat, pre.code-js {
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 0.9rem;
+  border-radius: var(--radius);
+  overflow-x: auto;
+  font-family: 'Fira Code', 'Consolas', 'Courier New', monospace;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  margin: 0.5rem 0;
+}
+
+/* WAT Syntax Highlighting */
+.wat-keyword  { color: #c792ea; }  /* purple  - module, func, export, import ... */
+.wat-type     { color: #89ddff; }  /* cyan    - i32, i64, f32, f64 */
+.wat-name     { color: #82aaff; }  /* blue    - $fibonacci, $n ... */
+.wat-string   { color: #c3e88d; }  /* green   - "fibonacci", "memory" ... */
+.wat-number   { color: #f78c6c; }  /* orange  - 0, 1, 65536 ... */
+.wat-paren    { color: #89ddff; }  /* cyan    - ( ) */
+.wat-comment  { color: #546e7a; font-style: italic; } /* dim - ;; ... */
+
+/* JS code comments */
+.code-comment { color: #546e7a; font-style: italic; }
+
+/* ── RESPONSIVE ──────────────────────────────────────────── */
+@media (max-width: 700px) {
+  main.grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-full {
+    grid-column: 1;
+  }
+
+  .results-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .speedup-card {
+    grid-row: 1;
+  }
+}


### PR DESCRIPTION
New files:
- wasm/Cargo.toml: cdylib crate with wasm-bindgen dependency
- wasm/src/lib.rs: Rust → Wasm exports demonstrating 4 concepts:
  exports, private functions, imports (console.log), linear memory
- www/index.html: 3-panel educational UI (benchmark, memory, module anatomy)
- www/style.css: Dark code blocks with WAT syntax highlighting
- www/app.js: ES module loading Wasm, zero-copy Float32Array demo
- build.sh: Step-by-step build script that serves as a learning guide

Run: bash build.sh → open http://localhost:8080

https://claude.ai/code/session_01VemoD7aRkbfvhYGejmtS47